### PR TITLE
Calculate Robinson-Foulds (RF) distance

### DIFF
--- a/algorithm_stats.py
+++ b/algorithm_stats.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import sys
+
+def plot_algorithm_stats(filename):
+    df = pd.read_csv (filename)
+    df.plot(x="k", y=["MST nodes", "Global tree vertices", "V size","MP score of local", "Global tree edges"])
+    plot = df.plot(x="k", y=["MST nodes", "Global tree vertices", "V size","MP score of local", "Global tree edges"])
+    plt.xlabel("iteration (k)")
+    filename_without_folder = filename.split('/')[-1]
+
+    dataset_threshold = filename_without_folder.split('.')[0]
+    dataset_threshold_parts = dataset_threshold.split('_')
+    dataset = dataset_threshold_parts[0]
+    threshold = dataset_threshold_parts[1]
+    
+    plt.title(f'influenza_{dataset}.fasta, threshold = {threshold}')
+    fig = plot.get_figure()
+    plot_filename = f'Result/{dataset_threshold}_stats_plot.png'
+    print(f'plot_filename: {plot_filename}')
+    fig.savefig(plot_filename)
+
+if __name__ == "__main__":
+    plot_algorithm_stats(sys.argv[1])

--- a/rf_distance.py
+++ b/rf_distance.py
@@ -19,9 +19,10 @@ def calculate_rf_distance(newick_our_method, newick_benchmark):
 
     # RF(T1, T2) = |S1⋃S2| − |S1⋂S2|
     print(len(edges_our_method))
-    RF_dist = edges_union - edges_intersection
-    print(f'Robinson-Foulds distance = |S1⋃S2| − |S1⋂S2| = {len(edges_union)} - {len(edges_intersection)} = {len(edges_union) - len(edges_intersection)} over a total of {rf_max}')
-    return RF_dist
+    normalized_RF_dist = (len(edges_union) - len(edges_intersection))/len(edges_union)
+    print(f'Robinson-Foulds (RF) distance = |S1⋃S2| − |S1⋂S2| = {len(edges_union)} - {len(edges_intersection)} = {len(edges_union) - len(edges_intersection)} over a total of {rf_max}')
+    print(f'Normalized Robinson-Foulds distance = RF / |S1⋃S2| = {normalized_RF_dist}')
+    return normalized_RF_dist
 
 if __name__ == "__main__":
     newick_our_method, newick_raxml_benchmark = parse_newick_string(sys.argv[1], sys.argv[2])

--- a/rf_distance.py
+++ b/rf_distance.py
@@ -1,0 +1,28 @@
+from ete3 import Tree
+import sys
+
+def parse_newick_string(filename_our_method, filename_benchmark):
+    newick_our_method = ""
+    newick_raxml_benchmark = ""
+    with open(filename_our_method, 'r') as file_our_method:
+        newick_our_method = file_our_method.readlines()[-1]
+    with open(filename_benchmark, 'r') as file_benchmark:
+        newick_raxml_benchmark = file_benchmark.read()
+    return newick_our_method, newick_raxml_benchmark
+
+def calculate_rf_distance(newick_our_method, newick_benchmark):
+    tree_our_method = Tree(newick_our_method)
+    tree_benchmark = Tree(newick_benchmark)
+    (rf, rf_max, names, edges_our_method, edges_benchmark, discarded_edges_our_method, discarded_edges_benchmark) = tree_our_method.robinson_foulds(tree_benchmark, unrooted_trees=True)
+    edges_union = edges_our_method.union(edges_benchmark)
+    edges_intersection = edges_our_method.intersection(edges_benchmark)
+
+    # RF(T1, T2) = |S1⋃S2| − |S1⋂S2|
+    print(len(edges_our_method))
+    RF_dist = edges_union - edges_intersection
+    print(f'Robinson-Foulds distance = |S1⋃S2| − |S1⋂S2| = {len(edges_union)} - {len(edges_intersection)} = {len(edges_union) - len(edges_intersection)} over a total of {rf_max}')
+    return RF_dist
+
+if __name__ == "__main__":
+    newick_our_method, newick_raxml_benchmark = parse_newick_string(sys.argv[1], sys.argv[2])
+    calculate_rf_distance(newick_our_method, newick_raxml_benchmark)


### PR DESCRIPTION
This PR allows us to calculate the RF distance for a given result from our method vs. the raxml benchmark. It uses the ete3 package. The calculation was covered in [Lecture 5, slide 13](https://drive.google.com/file/d/1s69LXhSWWK6l2IdiW4lEv4E-jQ52LeBk/view)

To Run: 
```python
python3 rf_distance.py path/to/our_method_results_file path/to/benchmark_results_file
```
e.g. 
```python
python3 rf_distance.py ../../final-project/results/1019_15.log ../../final-project/results/influenza_1019.raxml.bestTree.tre
```